### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/com.irccloud.desktop.json
+++ b/com.irccloud.desktop.json
@@ -97,7 +97,8 @@
         {
           "type": "script",
           "commands": [
-            "exec /app/irccloud/irccloud --no-sandbox \"$@\""
+            "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+            "exec zypak-wrapper/app/irccloud/irccloud \"$@\""
           ],
           "dest-filename": "irccloud"
         },

--- a/com.irccloud.desktop.json
+++ b/com.irccloud.desktop.json
@@ -98,7 +98,7 @@
           "type": "script",
           "commands": [
             "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-            "exec zypak-wrapper/app/irccloud/irccloud \"$@\""
+            "exec zypak-wrapper /app/irccloud/irccloud \"$@\""
           ],
           "dest-filename": "irccloud"
         },


### PR DESCRIPTION
Also: export `TMPDIR`  to solve multiple instance issue.