### PR TITLE
update to 21.08 runtime

### DIFF
--- a/com.irccloud.desktop.json
+++ b/com.irccloud.desktop.json
@@ -1,10 +1,10 @@
 {
   "app-id": "com.irccloud.desktop",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "19.08",
+  "runtime-version": "21.08",
   "sdk": "org.freedesktop.Sdk",
   "base": "org.electronjs.Electron2.BaseApp",
-  "base-version": "19.08",
+  "base-version": "21.08",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.node12"
   ],


### PR DESCRIPTION
The 19.08 era runtimes are now out of security support, this upgrades to 21.08 which is good for two years. I've tested locally and it works fine.